### PR TITLE
add namespace to all yml definition files

### DIFF
--- a/models/marts/dim_column.yml
+++ b/models/marts/dim_column.yml
@@ -1,69 +1,70 @@
 version: 2
-models:
-- name: dim_column
-  description: "{{ doc('dim_column')}}"
-  config:
-    contract:
-      enforced: true
-  meta:
-    label: Column Dimension
-  columns:
-  - name: column_key
-    data_type: text
-    description: ''
-    tests:
-    - not_null
-    - unique
+dbt_observability:
+  models:
+  - name: dim_column
+    description: "{{ doc('dim_column')}}"
+    config:
+      contract:
+        enforced: true
     meta:
-      label: column_key
-      hidden: true
-    constraints:
-      - type: not_null
-      - type: unique
-      - type: primary_key
-        warn_unenforced: false
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: column_name
-    description: ''
-    data_type: text
-    meta:
-      label: Column Name
-  - name: data_type
-    description: ''
-    data_type: text
-    meta:
-      label: Data Type
-  - name: tags
-    description: ''
-    data_type: text
-    meta:
-      label: Tags
-  - name: meta
-    description: ''
-    data_type: text
-    meta:
-      label: Meta
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
+      label: Column Dimension
+    columns:
+    - name: column_key
+      data_type: text
+      description: ''
+      tests:
+      - not_null
+      - unique
+      meta:
+        label: column_key
+        hidden: true
+      constraints:
+        - type: not_null
+        - type: unique
+        - type: primary_key
+          warn_unenforced: false
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: column_name
+      description: ''
+      data_type: text
+      meta:
+        label: Column Name
+    - name: data_type
+      description: ''
+      data_type: text
+      meta:
+        label: Data Type
+    - name: tags
+      description: ''
+      data_type: text
+      meta:
+        label: Tags
+    - name: meta
+      description: ''
+      data_type: text
+      meta:
+        label: Meta
+    - name: description
+      description: ''
+      data_type: text
+      meta:
+        label: Description

--- a/models/marts/dim_date.yml
+++ b/models/marts/dim_date.yml
@@ -1,118 +1,119 @@
 version: 2
-models:
-- name: dim_date
-  description: ''
-  config:
-    contract:
-      enforced: true
-  meta:
-    label: Date Dimension
-  columns:
-  - name: date_key
+dbt_observability:
+  models:
+  - name: dim_date
     description: ''
-    data_type: text
+    config:
+      contract:
+        enforced: true
     meta:
-      label: date_key
-      hidden: true
-    tests:
-    - not_null
-    - unique
-    constraints:
-    - type: not_null
-    - type: unique
-    - type: primary_key
-      warn_unenforced: false
-  - name: date_full
-    description: ''
-    data_type: date
-    meta:
-      label: Date Full
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD
-  - name: fiscal_year
-    description: ''
-    meta:
-      label: Fiscal Year
-    data_type: integer
-  - name: fiscal_quarter
-    description: ''
-    meta:
-      label: Fiscal Quarter
-    data_type: integer
-  - name: fiscal_month
-    description: ''
-    meta:
-      label: Fiscal Month
-    data_type: integer
-  - name: fiscal_month_name
-    description: ''
-    meta:
-      label: Fiscal Month Name (Full)
-    data_type: text
-  - name: fiscal_month_abbrev
-    description: ''
-    meta:
-      label: Fiscal Month Name (Abbrev)
-    data_type: text
-  - name: calendar_year
-    description: ''
-    meta:
-      label: Calendar Year
-    data_type: integer
-  - name: calendar_quarter
-    description: ''
-    meta:
-      label: Calendar Quarter
-    data_type: integer
-  - name: calendar_month_nbr
-    description: ''
-    meta:
-      label: Calendar Month Number
-    data_type: integer
-  - name: calendar_month_name
-    description: ''
-    meta:
-      label: Calendar Month Name (Full)
-    data_type: text
-  - name: calendar_month_abbrev
-    description: ''
-    meta:
-      label: Calendar Month Name (Abbrev)
-    data_type: text
-  - name: calendar_week_of_year
-    description: ''
-    meta:
-      label: Calendar Week of Year
-    data_type: integer
-  - name: calendar_day_of_year
-    description: ''
-    meta:
-      label: Calendar Day of Year
-    data_type: integer
-  - name: day_of_month
-    description: ''
-    meta:
-      label: Day of Month
-    data_type: integer
-  - name: day_of_week
-    description: ''
-    meta:
-      label: Day of Week
-    data_type: integer
-  - name: day_of_week_abbrev
-    description: ''
-    meta:
-      label: Day of Week (Abbrev)
-    data_type: text
-  - name: month_day_num
-    description: ''
-    meta:
-      label: Month Day Number
-    data_type: text
-  - name: month_day_desc
-    description: ''
-    meta:
-      label: Month Day Description
-    data_type: text
+      label: Date Dimension
+    columns:
+    - name: date_key
+      description: ''
+      data_type: text
+      meta:
+        label: date_key
+        hidden: true
+      tests:
+      - not_null
+      - unique
+      constraints:
+      - type: not_null
+      - type: unique
+      - type: primary_key
+        warn_unenforced: false
+    - name: date_full
+      description: ''
+      data_type: date
+      meta:
+        label: Date Full
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD
+    - name: fiscal_year
+      description: ''
+      meta:
+        label: Fiscal Year
+      data_type: integer
+    - name: fiscal_quarter
+      description: ''
+      meta:
+        label: Fiscal Quarter
+      data_type: integer
+    - name: fiscal_month
+      description: ''
+      meta:
+        label: Fiscal Month
+      data_type: integer
+    - name: fiscal_month_name
+      description: ''
+      meta:
+        label: Fiscal Month Name (Full)
+      data_type: text
+    - name: fiscal_month_abbrev
+      description: ''
+      meta:
+        label: Fiscal Month Name (Abbrev)
+      data_type: text
+    - name: calendar_year
+      description: ''
+      meta:
+        label: Calendar Year
+      data_type: integer
+    - name: calendar_quarter
+      description: ''
+      meta:
+        label: Calendar Quarter
+      data_type: integer
+    - name: calendar_month_nbr
+      description: ''
+      meta:
+        label: Calendar Month Number
+      data_type: integer
+    - name: calendar_month_name
+      description: ''
+      meta:
+        label: Calendar Month Name (Full)
+      data_type: text
+    - name: calendar_month_abbrev
+      description: ''
+      meta:
+        label: Calendar Month Name (Abbrev)
+      data_type: text
+    - name: calendar_week_of_year
+      description: ''
+      meta:
+        label: Calendar Week of Year
+      data_type: integer
+    - name: calendar_day_of_year
+      description: ''
+      meta:
+        label: Calendar Day of Year
+      data_type: integer
+    - name: day_of_month
+      description: ''
+      meta:
+        label: Day of Month
+      data_type: integer
+    - name: day_of_week
+      description: ''
+      meta:
+        label: Day of Week
+      data_type: integer
+    - name: day_of_week_abbrev
+      description: ''
+      meta:
+        label: Day of Week (Abbrev)
+      data_type: text
+    - name: month_day_num
+      description: ''
+      meta:
+        label: Month Day Number
+      data_type: text
+    - name: month_day_desc
+      description: ''
+      meta:
+        label: Month Day Description
+      data_type: text

--- a/models/marts/dim_execution.yml
+++ b/models/marts/dim_execution.yml
@@ -1,63 +1,64 @@
 version: 2
-models:
-- name: dim_execution
-  description: ''
-  config:
-    contract:
-      enforced: true
-  meta:
-    label: Execution Dimension
-  columns:
-  - name: execution_key
+dbt_observability:
+  models:
+  - name: dim_execution
     description: ''
-    data_type: text
+    config:
+      contract:
+        enforced: true
     meta:
-      hidden: true
-    constraints:
-      - type: not_null
-      - type: unique
-      - type: primary_key
-        warn_unenforced: false
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: status
-    description: ''
-    data_type: text
-    meta:
-      label: Status
-  - name: materialization
-    description: ''
-    data_type: text
-    meta:
-      label: Materialization
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: most_recent_run
-    description: ''
-    data_type: text
-    meta:
-      label: Most Recent Run
+      label: Execution Dimension
+    columns:
+    - name: execution_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+        - type: unique
+        - type: primary_key
+          warn_unenforced: false
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: status
+      description: ''
+      data_type: text
+      meta:
+        label: Status
+    - name: materialization
+      description: ''
+      data_type: text
+      meta:
+        label: Materialization
+    - name: schema_name
+      description: ''
+      data_type: text
+      meta:
+        label: Schema Name
+    - name: most_recent_run
+      description: ''
+      data_type: text
+      meta:
+        label: Most Recent Run

--- a/models/marts/dim_exposure.yml
+++ b/models/marts/dim_exposure.yml
@@ -1,79 +1,80 @@
 version: 2
-models:
-- name: dim_exposure
-  description: ''
-  meta:
-    label: Exposure Dimension
-  columns:
-  - name: exposure_key
+dbt_observability:
+  models:
+  - name: dim_exposure
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: type
-    description: ''
-    data_type: text
-    meta:
-      label: Type
-  - name: owner
-    description: ''
-    data_type: text
-    meta:
-      label: Owner
-  - name: maturity
-    description: ''
-    data_type: text
-    meta:
-      label: Maturity
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
-  - name: url
-    description: ''
-    data_type: text
-    meta:
-      label: URL
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
+      label: Exposure Dimension
+    columns:
+    - name: exposure_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: type
+      description: ''
+      data_type: text
+      meta:
+        label: Type
+    - name: owner
+      description: ''
+      data_type: text
+      meta:
+        label: Owner
+    - name: maturity
+      description: ''
+      data_type: text
+      meta:
+        label: Maturity
+    - name: path
+      description: ''
+      data_type: text
+      meta:
+        label: Path
+    - name: description
+      description: ''
+      data_type: text
+      meta:
+        label: Description
+    - name: url
+      description: ''
+      data_type: text
+      meta:
+        label: URL
+    - name: package_name
+      description: ''
+      data_type: text
+      meta:
+        label: Package Name
+    - name: depends_on_nodes
+      description: ''
+      data_type: text
+      meta:
+        label: Depends On Nodes

--- a/models/marts/dim_invocation.yml
+++ b/models/marts/dim_invocation.yml
@@ -1,96 +1,97 @@
 version: 2
-models:
-- name: dim_invocation
-  description: ''
-  meta:
-    label: Invocation Dimension
-  columns:
-  - name: invocation_key
+dbt_observability:
+  models:
+  - name: dim_invocation
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: command_invocation_id
-    description: ''
-  - name: dbt_version
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Version
-  - name: project_name
-    description: ''
-    data_type: text
-    meta:
-      label: Project Name
-  - name: dbt_command
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Command
-  - name: full_refresh_flag
-    description: ''
-    data_type: text
-    meta:
-      label: Full Refresh Flag
-  - name: target_type
-    description: ''
-    data_type: text
-    meta:
-      label: Target Type
-  - name: target_profile_name
-    description: ''
-    data_type: text
-    meta:
-      label: Target Profile Name
-  - name: target_name
-    description: ''
-    data_type: text
-    meta:
-      label: Target Name
-  - name: target_schema
-    description: ''
-    data_type: text
-    meta:
-      label: Target Schema
-  - name: target_threads
-    description: ''
-    data_type: int
-    meta:
-      label: Target Threads
-  - name: dbt_cloud_project_id
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Cloud Project ID
-  - name: dbt_cloud_job_id
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Cloud Job ID
-  - name: dbt_cloud_run_id
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Cloud Run ID
-  - name: dbt_cloud_run_reason_category
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Cloud Run Reason Category
-  - name: dbt_cloud_run_reason
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Cloud Run Reason
-  - name: env_vars
-    description: ''
-    data_type: text
-    meta:
-      label: Environment Variables
-  - name: dbt_vars
-    description: ''
-    data_type: text
-    meta:
-      label: dbt Variables
+      label: Invocation Dimension
+    columns:
+    - name: invocation_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: command_invocation_id
+      description: ''
+    - name: dbt_version
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Version
+    - name: project_name
+      description: ''
+      data_type: text
+      meta:
+        label: Project Name
+    - name: dbt_command
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Command
+    - name: full_refresh_flag
+      description: ''
+      data_type: text
+      meta:
+        label: Full Refresh Flag
+    - name: target_type
+      description: ''
+      data_type: text
+      meta:
+        label: Target Type
+    - name: target_profile_name
+      description: ''
+      data_type: text
+      meta:
+        label: Target Profile Name
+    - name: target_name
+      description: ''
+      data_type: text
+      meta:
+        label: Target Name
+    - name: target_schema
+      description: ''
+      data_type: text
+      meta:
+        label: Target Schema
+    - name: target_threads
+      description: ''
+      data_type: int
+      meta:
+        label: Target Threads
+    - name: dbt_cloud_project_id
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Cloud Project ID
+    - name: dbt_cloud_job_id
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Cloud Job ID
+    - name: dbt_cloud_run_id
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Cloud Run ID
+    - name: dbt_cloud_run_reason_category
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Cloud Run Reason Category
+    - name: dbt_cloud_run_reason
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Cloud Run Reason
+    - name: env_vars
+      description: ''
+      data_type: text
+      meta:
+        label: Environment Variables
+    - name: dbt_vars
+      description: ''
+      data_type: text
+      meta:
+        label: dbt Variables

--- a/models/marts/dim_metric.yml
+++ b/models/marts/dim_metric.yml
@@ -1,94 +1,95 @@
 version: 2
-models:
-- name: dim_metric
-  description: ''
-  meta:
-    label: Metric Dimension
-  columns:
-  - name: metric_key
+dbt_observability:
+  models:
+  - name: dim_metric
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  # - name: resource_type
-  #   description: ''
-  #   data_type: text
-  #   meta:
-  #     label: Resource Type
-  # - name: project
-  #   description: ''
-  #   data_type: text
-  #   meta:
-  #     label: Project
-  # - name: resource_name
-  #   description: ''
-  #   data_type: text
-  #   meta:
-  #     label: Resource Name
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: label
-    description: ''
-    data_type: text
-    meta:
-      label: Label
-  - name: model
-    description: ''
-    data_type: text
-    meta:
-      label: Model
-  - name: expression
-    description: ''
-    data_type: text
-    meta:
-      label: Expression
-  - name: calculation_method
-    description: ''
-    data_type: text
-    meta:
-      label: Calculation Method
-  - name: filters
-    description: ''
-    data_type: text
-    meta:
-      label: Filters
-  - name: time_grains
-    description: ''
-    data_type: text
-    meta:
-      label: Time Grains
-  - name: dimensions
-    description: ''
-    data_type: text
-    meta:
-      label: Dimensions
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: meta
-    description: ''
-    data_type: text
-    meta:
-      label: Meta
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
+      label: Metric Dimension
+    columns:
+    - name: metric_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    # - name: resource_type
+    #   description: ''
+    #   data_type: text
+    #   meta:
+    #     label: Resource Type
+    # - name: project
+    #   description: ''
+    #   data_type: text
+    #   meta:
+    #     label: Project
+    # - name: resource_name
+    #   description: ''
+    #   data_type: text
+    #   meta:
+    #     label: Resource Name
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: label
+      description: ''
+      data_type: text
+      meta:
+        label: Label
+    - name: model
+      description: ''
+      data_type: text
+      meta:
+        label: Model
+    - name: expression
+      description: ''
+      data_type: text
+      meta:
+        label: Expression
+    - name: calculation_method
+      description: ''
+      data_type: text
+      meta:
+        label: Calculation Method
+    - name: filters
+      description: ''
+      data_type: text
+      meta:
+        label: Filters
+    - name: time_grains
+      description: ''
+      data_type: text
+      meta:
+        label: Time Grains
+    - name: dimensions
+      description: ''
+      data_type: text
+      meta:
+        label: Dimensions
+    - name: package_name
+      description: ''
+      data_type: text
+      meta:
+        label: Package Name
+    - name: meta
+      description: ''
+      data_type: text
+      meta:
+        label: Meta
+    - name: depends_on_nodes
+      description: ''
+      data_type: text
+      meta:
+        label: Depends On Nodes
+    - name: description
+      description: ''
+      data_type: text
+      meta:
+        label: Description

--- a/models/marts/dim_model.yml
+++ b/models/marts/dim_model.yml
@@ -1,89 +1,90 @@
 version: 2
-models:
-- name: dim_model
-  description: ''
-  meta:
-    label: Model Dimension
-  columns:
-  - name: model_key
+dbt_observability:
+  models:
+  - name: dim_model
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: database_name
-    description: ''
-    data_type: text
-    meta:
-      label: Database Name
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: checksum
-    description: ''
-    data_type: text
-    meta:
-      label: Checksum
-  - name: materialization
-    description: ''
-    data_type: text
-    meta:
-      label: Materialization
-  - name: tags
-    description: ''
-    data_type: text
-    meta:
-      label: Tags
-  - name: meta
-    description: ''
-    data_type: text
-    meta:
-      label: Meta
-  - name: description
-    description: ''
-    data_type: text
-    meta:
-      label: Description
-  - name: is_tested
-    description: ''
-    data_type: text
-    meta:
-      label: Model Is Tested
+      label: Model Dimension
+    columns:
+    - name: model_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: database_name
+      description: ''
+      data_type: text
+      meta:
+        label: Database Name
+    - name: schema_name
+      description: ''
+      data_type: text
+      meta:
+        label: Schema Name
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: package_name
+      description: ''
+      data_type: text
+      meta:
+        label: Package Name
+    - name: path
+      description: ''
+      data_type: text
+      meta:
+        label: Path
+    - name: checksum
+      description: ''
+      data_type: text
+      meta:
+        label: Checksum
+    - name: materialization
+      description: ''
+      data_type: text
+      meta:
+        label: Materialization
+    - name: tags
+      description: ''
+      data_type: text
+      meta:
+        label: Tags
+    - name: meta
+      description: ''
+      data_type: text
+      meta:
+        label: Meta
+    - name: description
+      description: ''
+      data_type: text
+      meta:
+        label: Description
+    - name: is_tested
+      description: ''
+      data_type: text
+      meta:
+        label: Model Is Tested

--- a/models/marts/dim_seed.yml
+++ b/models/marts/dim_seed.yml
@@ -1,64 +1,65 @@
 version: 2
-models:
-- name: dim_seed
-  description: ''
-  meta:
-    label: Seed Dimension
-  columns:
-  - name: seed_key
+dbt_observability:
+  models:
+  - name: dim_seed
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: database_name
-    description: ''
-    data_type: text
-    meta:
-      label: Database Name
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: checksum
-    description: ''
-    data_type: text
-    meta:
-      label: Checksum
+      label: Seed Dimension
+    columns:
+    - name: seed_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: database_name
+      description: ''
+      data_type: text
+      meta:
+        label: Database Name
+    - name: schema_name
+      description: ''
+      data_type: text
+      meta:
+        label: Schema Name
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: package_name
+      description: ''
+      data_type: text
+      meta:
+        label: Package Name
+    - name: path
+      description: ''
+      data_type: text
+      meta:
+        label: Path
+    - name: checksum
+      description: ''
+      data_type: text
+      meta:
+        label: Checksum

--- a/models/marts/dim_snapshot.yml
+++ b/models/marts/dim_snapshot.yml
@@ -1,74 +1,75 @@
 version: 2
-models:
-- name: dim_snapshot
-  description: ''
-  meta:
-    label: Snapshot Dimension
-  columns:
-  - name: snapshot_key
+dbt_observability:
+  models:
+  - name: dim_snapshot
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: database_name
-    description: ''
-    data_type: text
-    meta:
-      label: Database Name
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
-  - name: package_name
-    description: ''
-    data_type: text
-    meta:
-      label: Package Name
-  - name: path
-    description: ''
-    data_type: text
-    meta:
-      label: Path
-  - name: checksum
-    description: ''
-    data_type: text
-    meta:
-      label: Checksum
-  - name: strategy
-    description: ''
-    data_type: text
-    meta:
-      label: Strategy
+      label: Snapshot Dimension
+    columns:
+    - name: snapshot_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: database_name
+      description: ''
+      data_type: text
+      meta:
+        label: Database Name
+    - name: schema_name
+      description: ''
+      data_type: text
+      meta:
+        label: Schema Name
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: depends_on_nodes
+      description: ''
+      data_type: text
+      meta:
+        label: Depends On Nodes
+    - name: package_name
+      description: ''
+      data_type: text
+      meta:
+        label: Package Name
+    - name: path
+      description: ''
+      data_type: text
+      meta:
+        label: Path
+    - name: checksum
+      description: ''
+      data_type: text
+      meta:
+        label: Checksum
+    - name: strategy
+      description: ''
+      data_type: text
+      meta:
+        label: Strategy

--- a/models/marts/dim_source.yml
+++ b/models/marts/dim_source.yml
@@ -1,74 +1,75 @@
 version: 2
-models:
-- name: dim_source
-  description: ''
-  meta:
-    label: Source Dimension
-  columns:
-  - name: source_key
+dbt_observability:
+  models:
+  - name: dim_source
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: database_name
-    description: ''
-    data_type: text
-    meta:
-      label: Database Name
-  - name: schema_name
-    description: ''
-    data_type: text
-    meta:
-      label: Schema Name
-  - name: source_name
-    description: ''
-    data_type: text
-    meta:
-      label: Source Name
-  - name: loader
-    description: ''
-    data_type: text
-    meta:
-      label: Loader
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: identifier
-    description: ''
-    data_type: text
-    meta:
-      label: Identifier
-  - name: loaded_at_field
-    description: ''
-    data_type: text
-    meta:
-      label: Loaded At Field
-  - name: freshness
-    description: ''
-    data_type: text
-    meta:
-      label: Freshness
+      label: Source Dimension
+    columns:
+    - name: source_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: database_name
+      description: ''
+      data_type: text
+      meta:
+        label: Database Name
+    - name: schema_name
+      description: ''
+      data_type: text
+      meta:
+        label: Schema Name
+    - name: source_name
+      description: ''
+      data_type: text
+      meta:
+        label: Source Name
+    - name: loader
+      description: ''
+      data_type: text
+      meta:
+        label: Loader
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: identifier
+      description: ''
+      data_type: text
+      meta:
+        label: Identifier
+    - name: loaded_at_field
+      description: ''
+      data_type: text
+      meta:
+        label: Loaded At Field
+    - name: freshness
+      description: ''
+      data_type: text
+      meta:
+        label: Freshness

--- a/models/marts/dim_test.yml
+++ b/models/marts/dim_test.yml
@@ -1,59 +1,60 @@
 version: 2
-models:
-- name: dim_test
-  description: ''
-  meta:
-    label: Test Dimension
-  columns:
-  - name: test_key
+dbt_observability:
+  models:
+  - name: dim_test
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: node_id
-    description: ''
-    data_type: text
-    meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: name
-    description: ''
-    data_type: text
-    meta:
-      label: Name
-  - name: depends_on_nodes
-    description: ''
-    data_type: text
-    meta:
-      label: Depends On Nodes
-  - name: test_path
-    description: ''
-    data_type: text
-    meta:
-      label: Test Path
-  - name: tags
-    description: ''
-    data_type: text
-    meta:
-      label: Tags
-  - name: test_metadata
-    description: ''
-    data_type: text
-    meta:
-      label: Test Metadata
+      label: Test Dimension
+    columns:
+    - name: test_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: name
+      description: ''
+      data_type: text
+      meta:
+        label: Name
+    - name: depends_on_nodes
+      description: ''
+      data_type: text
+      meta:
+        label: Depends On Nodes
+    - name: test_path
+      description: ''
+      data_type: text
+      meta:
+        label: Test Path
+    - name: tags
+      description: ''
+      data_type: text
+      meta:
+        label: Tags
+    - name: test_metadata
+      description: ''
+      data_type: text
+      meta:
+        label: Test Metadata

--- a/models/marts/fact_column.yml
+++ b/models/marts/fact_column.yml
@@ -1,109 +1,110 @@
 version: 2
-models:
-- name: fact_column
-  description: ''
-  meta:
-    label: Column Fact
-    joins:
-      - to: dim_column
-        type: inner
-        join_on:
-          - from_field: column_key
-            exp: '='
-            to_field: column_key
-      - to: dim_execution
-        type: inner
-        join_on:
-          - from_field: execution_key
-            exp: '='
-            to_field: execution_key
-  columns:
-  - name: column_key
-    data_type: text
-    meta:
-      hidden: true
-      datatype: text
-    constraints:
-      - type: not_null
-      - type: primary_key
-        warn_unenforced: false
-    tests:
-      - not_null
-      - unique
-      - relationships:
-          to: ref('dim_column')
-          field: column_key
-  - name: execution_key
+dbt_observability:
+  models:
+  - name: fact_column
     description: ''
-    data_type: text
     meta:
-      hidden: true
-      datatype: text
-    constraints:
-      - type: not_null
-  - name: is_documented
-    description: ''
-    data_type: boolean
-    meta:
-      label: Is Documented
-      datatype: boolean
-  - name: row_count
-    description: ''
-    data_type: bigint
-    meta:
-      label: Row Count
-      datatype: bigint
-  - name: row_distinct
-    description: ''
-    data_type: bigint
-    meta:
-      label: Row Distinct
-      datatype: bigint
-  - name: row_null
-    description: ''
-    data_type: bigint
-    meta:
-      label: Row Null
-      datatype: bigint
-  - name: row_min
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Min
-      datatype: numeric
-  - name: row_max
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Max
-      datatype: numeric
-  - name: row_avg
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Avg
-      datatype: numeric
-  - name: row_sum
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Sum
-      datatype: numeric
-  - name: row_stdev
-    description: ''
-    data_type: numeric
-    meta:
-      label: Row Stdev
-      datatype: numeric
-  - name: is_metric
-    description: ''
-    data_type: boolean
-    meta:
-      label: Is Metric
-      datatype: boolean
-  - name: column_values
-    description: ''
-    data_type: text
-    meta:
-      label: Column Values
-      datatype: text
+      label: Column Fact
+      joins:
+        - to: dim_column
+          type: inner
+          join_on:
+            - from_field: column_key
+              exp: '='
+              to_field: column_key
+        - to: dim_execution
+          type: inner
+          join_on:
+            - from_field: execution_key
+              exp: '='
+              to_field: execution_key
+    columns:
+    - name: column_key
+      data_type: text
+      meta:
+        hidden: true
+        datatype: text
+      constraints:
+        - type: not_null
+        - type: primary_key
+          warn_unenforced: false
+      tests:
+        - not_null
+        - unique
+        - relationships:
+            to: ref('dim_column')
+            field: column_key
+    - name: execution_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+        datatype: text
+      constraints:
+        - type: not_null
+    - name: is_documented
+      description: ''
+      data_type: boolean
+      meta:
+        label: Is Documented
+        datatype: boolean
+    - name: row_count
+      description: ''
+      data_type: bigint
+      meta:
+        label: Row Count
+        datatype: bigint
+    - name: row_distinct
+      description: ''
+      data_type: bigint
+      meta:
+        label: Row Distinct
+        datatype: bigint
+    - name: row_null
+      description: ''
+      data_type: bigint
+      meta:
+        label: Row Null
+        datatype: bigint
+    - name: row_min
+      description: ''
+      data_type: numeric
+      meta:
+        label: Row Min
+        datatype: numeric
+    - name: row_max
+      description: ''
+      data_type: numeric
+      meta:
+        label: Row Max
+        datatype: numeric
+    - name: row_avg
+      description: ''
+      data_type: numeric
+      meta:
+        label: Row Avg
+        datatype: numeric
+    - name: row_sum
+      description: ''
+      data_type: numeric
+      meta:
+        label: Row Sum
+        datatype: numeric
+    - name: row_stdev
+      description: ''
+      data_type: numeric
+      meta:
+        label: Row Stdev
+        datatype: numeric
+    - name: is_metric
+      description: ''
+      data_type: boolean
+      meta:
+        label: Is Metric
+        datatype: boolean
+    - name: column_values
+      description: ''
+      data_type: text
+      meta:
+        label: Column Values
+        datatype: text

--- a/models/marts/fact_execution.yml
+++ b/models/marts/fact_execution.yml
@@ -1,206 +1,207 @@
 version: 2
-models:
-- name: fact_execution
-  description: ''
-  meta:
-    label: Execution Fact
-    display_index: 1
-    joins:
-      - to: dim_execution
-        type: inner
-        join_on:
-          - from_field: execution_key
-            exp: '='
-            to_field: execution_key
-      - to: dim_invocation
-        type: inner
-        join_on:
-          - from_field: invocation_key
-            exp: '='
-            to_field: invocation_key
-      - to: dim_model
-        type: inner
-        join_on:
-          - from_field: model_key
-            exp: '='
-            to_field: model_key
-      - to: dim_test
-        type: inner
-        join_on:
-          - from_field: test_key
-            exp: '='
-            to_field: test_key
-      - to: dim_seed
-        type: inner
-        join_on:
-          - from_field: seed_key
-            exp: '='
-            to_field: seed_key
-      - to: dim_source
-        type: inner
-        join_on:
-          - from_field: source_key
-            exp: '='
-            to_field: source_key
-      - to: dim_snapshot
-        type: inner
-        join_on:
-          - from_field: snapshot_key
-            exp: '='
-            to_field: snapshot_key
-      - to: dim_metric
-        type: inner
-        join_on:
-          - from_field: metric_key
-            exp: '='
-            to_field: metric_key
-      - to: dim_exposure
-        type: inner
-        join_on:
-          - from_field: exposure_key
-            exp: '='
-            to_field: exposure_key
-      - to: dim_date
-        type: inner
-        join_on:
-          - from_field: date_key
-            exp: '='
-            to_field: date_key
-  columns:
-  - name: execution_key
+dbt_observability:
+  models:
+  - name: fact_execution
     description: ''
     meta:
-      hidden: true
-    tests:
-    - not_null
-    - unique
-  - name: invocation_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: model_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: column_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: test_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: seed_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: source_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: snapshot_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: metric_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: exposure_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: date_key
-    description: ''
-    data_type: text
-    meta:
-      hidden: true
-    constraints:
-      - type: not_null
-  - name: run_started_at
-    description: ''
-    data_type: timestamp
-    meta:
-      label: Run Started At
-      hidden: false
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD HH:mm:ss
-  - name: was_full_refresh
-    description: ''
-    data_type: boolean
-    meta:
-      label: Was Full Refresh
-      datatype: boolean
-  - name: thread_id
-    description: ''
-    data_type: integer
-    meta:
-      label: Thread ID
-      datatype: integer
-  - name: compile_started_at
-    description: ''
-    meta:
-      label: Compile Started At
-      hidden: false
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD HH:mm:ss
-    meta:
-      label: Compile Started At
-      hidden: false
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD HH:mm:ss
-  - name: query_completed_at
-    description: ''
-    meta:
-      label: Query Completed At
-      hidden: false
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD HH:mm:ss
-    meta:
-      label: Query Completed At
-      hidden: false
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD HH:mm:ss
-  - name: total_node_runtime
-    description: ''
-    data_type: numeric
-    meta:
-      label: Total Node Runtime
-      datatype: numeric
+      label: Execution Fact
+      display_index: 1
+      joins:
+        - to: dim_execution
+          type: inner
+          join_on:
+            - from_field: execution_key
+              exp: '='
+              to_field: execution_key
+        - to: dim_invocation
+          type: inner
+          join_on:
+            - from_field: invocation_key
+              exp: '='
+              to_field: invocation_key
+        - to: dim_model
+          type: inner
+          join_on:
+            - from_field: model_key
+              exp: '='
+              to_field: model_key
+        - to: dim_test
+          type: inner
+          join_on:
+            - from_field: test_key
+              exp: '='
+              to_field: test_key
+        - to: dim_seed
+          type: inner
+          join_on:
+            - from_field: seed_key
+              exp: '='
+              to_field: seed_key
+        - to: dim_source
+          type: inner
+          join_on:
+            - from_field: source_key
+              exp: '='
+              to_field: source_key
+        - to: dim_snapshot
+          type: inner
+          join_on:
+            - from_field: snapshot_key
+              exp: '='
+              to_field: snapshot_key
+        - to: dim_metric
+          type: inner
+          join_on:
+            - from_field: metric_key
+              exp: '='
+              to_field: metric_key
+        - to: dim_exposure
+          type: inner
+          join_on:
+            - from_field: exposure_key
+              exp: '='
+              to_field: exposure_key
+        - to: dim_date
+          type: inner
+          join_on:
+            - from_field: date_key
+              exp: '='
+              to_field: date_key
+    columns:
+    - name: execution_key
+      description: ''
+      meta:
+        hidden: true
+      tests:
+      - not_null
+      - unique
+    - name: invocation_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: model_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: column_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: test_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: seed_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: source_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: snapshot_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: metric_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: exposure_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: date_key
+      description: ''
+      data_type: text
+      meta:
+        hidden: true
+      constraints:
+        - type: not_null
+    - name: run_started_at
+      description: ''
+      data_type: timestamp
+      meta:
+        label: Run Started At
+        hidden: false
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD HH:mm:ss
+    - name: was_full_refresh
+      description: ''
+      data_type: boolean
+      meta:
+        label: Was Full Refresh
+        datatype: boolean
+    - name: thread_id
+      description: ''
+      data_type: integer
+      meta:
+        label: Thread ID
+        datatype: integer
+    - name: compile_started_at
+      description: ''
+      meta:
+        label: Compile Started At
+        hidden: false
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD HH:mm:ss
+      meta:
+        label: Compile Started At
+        hidden: false
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD HH:mm:ss
+    - name: query_completed_at
+      description: ''
+      meta:
+        label: Query Completed At
+        hidden: false
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD HH:mm:ss
+      meta:
+        label: Query Completed At
+        hidden: false
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD HH:mm:ss
+    - name: total_node_runtime
+      description: ''
+      data_type: numeric
+      meta:
+        label: Total Node Runtime
+        datatype: numeric

--- a/models/sources/all_executions.yml
+++ b/models/sources/all_executions.yml
@@ -1,33 +1,33 @@
 version: 2
-
-models:
-- name: all_executions
-  description: Contains data about all resource executions.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: was_full_refresh
-    description: '{{ doc("was_full_refresh") }}'
-  - name: thread_id
-    description: '{{ doc("thread_id") }}'
-  - name: status
-    description: '{{ doc("status") }}'
-  - name: compile_started_at
-    description: '{{ doc("compile_started_at") }}'
-  - name: query_completed_at
-    description: '{{ doc("query_completed_at") }}'
-  - name: total_node_runtime
-    description: '{{ doc("total_node_runtime") }}'
-  - name: materialization
-    description: '{{ doc("materialization") }}'
-  - name: schema_name
-    description: '{{ doc("schema_name") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: resource_type
-    description: '{{ doc("resource_type") }}'
+dbt_observability:
+  models:
+  - name: all_executions
+    description: Contains data about all resource executions.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: was_full_refresh
+      description: '{{ doc("was_full_refresh") }}'
+    - name: thread_id
+      description: '{{ doc("thread_id") }}'
+    - name: status
+      description: '{{ doc("status") }}'
+    - name: compile_started_at
+      description: '{{ doc("compile_started_at") }}'
+    - name: query_completed_at
+      description: '{{ doc("query_completed_at") }}'
+    - name: total_node_runtime
+      description: '{{ doc("total_node_runtime") }}'
+    - name: materialization
+      description: '{{ doc("materialization") }}'
+    - name: schema_name
+      description: '{{ doc("schema_name") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: resource_type
+      description: '{{ doc("resource_type") }}'
 

--- a/models/sources/columns.yml
+++ b/models/sources/columns.yml
@@ -1,57 +1,57 @@
 version: 2
-
-models:
-- name: columns
-  meta:
-    label: Columns
-  columns:
-  - name: command_invocation_id
-    description: ''
+dbt_observability:
+  models:
+  - name: columns
     meta:
-      label: Command Invocation Id
-  - name: node_id
-    description: ''
-    meta:
-      label: Node Id
-  - name: column_name
-    description: ''
-    meta:
-      label: Column Name
-  - name: data_type
-    description: ''
-    meta:
-      label: Data Type
-  - name: tags
-    description: ''
-    meta:
-      label: Tags
-  - name: meta
-    description: ''
-    meta:
-      label: Meta
-  - name: description
-    description: ''
-    meta:
-      label: Description
-  - name: is_documented
-    description: ''
-  - name: row_count
-    description: ''
-  - name: row_distinct
-    description: ''
-  - name: row_null
-    description: ''
-  - name: row_min
-    description: ''
-  - name: row_max
-    description: ''
-  - name: row_avg
-    description: ''
-  - name: row_sum
-    description: ''
-  - name: row_stdev
-    description: ''
-  - name: is_metric
-    description: ''
-  - name: column_values
+      label: Columns
+    columns:
+    - name: command_invocation_id
+      description: ''
+      meta:
+        label: Command Invocation Id
+    - name: node_id
+      description: ''
+      meta:
+        label: Node Id
+    - name: column_name
+      description: ''
+      meta:
+        label: Column Name
+    - name: data_type
+      description: ''
+      meta:
+        label: Data Type
+    - name: tags
+      description: ''
+      meta:
+        label: Tags
+    - name: meta
+      description: ''
+      meta:
+        label: Meta
+    - name: description
+      description: ''
+      meta:
+        label: Description
+    - name: is_documented
+      description: ''
+    - name: row_count
+      description: ''
+    - name: row_distinct
+      description: ''
+    - name: row_null
+      description: ''
+    - name: row_min
+      description: ''
+    - name: row_max
+      description: ''
+    - name: row_avg
+      description: ''
+    - name: row_sum
+      description: ''
+    - name: row_stdev
+      description: ''
+    - name: is_metric
+      description: ''
+    - name: column_values
     description: ''

--- a/models/sources/exposures.yml
+++ b/models/sources/exposures.yml
@@ -1,30 +1,30 @@
 version: 2
-
-models:
-- name: exposures
-  description: Dimension model that contains data about exposures.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: type
-    description: '{{ doc("type") }}'
-  - name: owner
-    description: '{{ doc("owner") }}'
-  - name: maturity
-    description: '{{ doc("maturity") }}'
-  - name: path
-    description: '{{ doc("path") }}'
-  - name: description
-    description: '{{ doc("description") }}'
-  - name: url
-    description: '{{ doc("url") }}'
-  - name: package_name
-    description: '{{ doc("package_name") }}'
-  - name: depends_on_nodes
-    description: '{{ doc("depends_on_nodes") }}'
+dbt_observability:
+  models:
+  - name: exposures
+    description: Dimension model that contains data about exposures.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: type
+      description: '{{ doc("type") }}'
+    - name: owner
+      description: '{{ doc("owner") }}'
+    - name: maturity
+      description: '{{ doc("maturity") }}'
+    - name: path
+      description: '{{ doc("path") }}'
+    - name: description
+      description: '{{ doc("description") }}'
+    - name: url
+      description: '{{ doc("url") }}'
+    - name: package_name
+      description: '{{ doc("package_name") }}'
+    - name: depends_on_nodes
+      description: '{{ doc("depends_on_nodes") }}'

--- a/models/sources/invocations.yml
+++ b/models/sources/invocations.yml
@@ -1,41 +1,42 @@
 version: 2
-models:
-- name: invocations
-  description: ''
-  columns:
-  - name: command_invocation_id
+dbt_observability:
+  models:
+  - name: invocations
     description: ''
-  - name: dbt_version
-    description: ''
-  - name: project_name
-    description: ''
-  - name: run_started_at
-    description: ''
-  - name: dbt_command
-    description: ''
-  - name: full_refresh_flag
-    description: ''
-  - name: target_type
-    description: ''
-  - name: target_profile_name
-    description: ''
-  - name: target_name
-    description: ''
-  - name: target_schema
-    description: ''
-  - name: target_threads
-    description: ''
-  - name: dbt_cloud_project_id
-    description: ''
-  - name: dbt_cloud_job_id
-    description: ''
-  - name: dbt_cloud_run_id
-    description: ''
-  - name: dbt_cloud_run_reason_category
-    description: ''
-  - name: dbt_cloud_run_reason
-    description: ''
-  - name: env_vars
-    description: ''
-  - name: dbt_vars
-    description: ''
+    columns:
+    - name: command_invocation_id
+      description: ''
+    - name: dbt_version
+      description: ''
+    - name: project_name
+      description: ''
+    - name: run_started_at
+      description: ''
+    - name: dbt_command
+      description: ''
+    - name: full_refresh_flag
+      description: ''
+    - name: target_type
+      description: ''
+    - name: target_profile_name
+      description: ''
+    - name: target_name
+      description: ''
+    - name: target_schema
+      description: ''
+    - name: target_threads
+      description: ''
+    - name: dbt_cloud_project_id
+      description: ''
+    - name: dbt_cloud_job_id
+      description: ''
+    - name: dbt_cloud_run_id
+      description: ''
+    - name: dbt_cloud_run_reason_category
+      description: ''
+    - name: dbt_cloud_run_reason
+      description: ''
+    - name: env_vars
+      description: ''
+    - name: dbt_vars
+      description: ''

--- a/models/sources/metrics.yml
+++ b/models/sources/metrics.yml
@@ -1,33 +1,34 @@
 version: 2
-models:
-- name: metrics
-  description: ''
-  columns:
-  - name: command_invocation_id
+dbt_observability:
+  models:
+  - name: metrics
     description: ''
-  - name: unique_id
-    description: ''
-  - name: name
-    description: ''
-  - name: label
-    description: ''
-  - name: model
-    description: ''
-  - name: expression
-    description: ''
-  - name: calculation_method
-    description: ''
-  - name: filters
-    description: ''
-  - name: time_grains
-    description: ''
-  - name: dimensions
-    description: ''
-  - name: package_name
-    description: ''
-  - name: meta
-    description: ''
-  - name: depends_on_nodes
-    description: ''
-  - name: description
-    description: ''
+    columns:
+    - name: command_invocation_id
+      description: ''
+    - name: unique_id
+      description: ''
+    - name: name
+      description: ''
+    - name: label
+      description: ''
+    - name: model
+      description: ''
+    - name: expression
+      description: ''
+    - name: calculation_method
+      description: ''
+    - name: filters
+      description: ''
+    - name: time_grains
+      description: ''
+    - name: dimensions
+      description: ''
+    - name: package_name
+      description: ''
+    - name: meta
+      description: ''
+    - name: depends_on_nodes
+      description: ''
+    - name: description
+      description: ''

--- a/models/sources/models.yml
+++ b/models/sources/models.yml
@@ -1,38 +1,38 @@
 version: 2
-
-models:
-- name: models
-  description: Dimension that contains data about models.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: database_name
-    description: '{{ doc("database_name") }}'
-  - name: schema_name
-    description: '{{ doc("schema_name") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: depends_on_nodes
-    description: '{{ doc("depends_on_nodes") }}'
-  - name: package_name
-    description: '{{ doc("package_name") }}'
-  - name: path
-    description: '{{ doc("path") }}'
-  - name: checksum
-    description: '{{ doc("checksum") }}'
-  - name: materialization
-    description: '{{ doc("materialization") }}'
-  - name: tags
-    description: '{{ doc("tags") }}'
-  - name: meta
-    description: '{{ doc("meta") }}'
-  - name: description
-    description: ''
-    meta:
-      label: Description
-  - name: total_rowcount
-    description: 'Total rowcount for the model'
+dbt_observability:
+  models:
+  - name: models
+    description: Dimension that contains data about models.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: database_name
+      description: '{{ doc("database_name") }}'
+    - name: schema_name
+      description: '{{ doc("schema_name") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: depends_on_nodes
+      description: '{{ doc("depends_on_nodes") }}'
+    - name: package_name
+      description: '{{ doc("package_name") }}'
+    - name: path
+      description: '{{ doc("path") }}'
+    - name: checksum
+      description: '{{ doc("checksum") }}'
+    - name: materialization
+      description: '{{ doc("materialization") }}'
+    - name: tags
+      description: '{{ doc("tags") }}'
+    - name: meta
+      description: '{{ doc("meta") }}'
+    - name: description
+      description: ''
+      meta:
+        label: Description
+    - name: total_rowcount
+      description: 'Total rowcount for the model'

--- a/models/sources/seeds.yml
+++ b/models/sources/seeds.yml
@@ -1,24 +1,24 @@
 version: 2
-
-models:
-- name: seeds
-  description: Dimension model that contains data about seeds.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: database_name
-    description: '{{ doc("database_name") }}'
-  - name: schema_name
-    description: '{{ doc("schema_name") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: package_name
-    description: '{{ doc("package_name") }}'
-  - name: path
-    description: '{{ doc("path") }}'
-  - name: checksum
-    description: '{{ doc("checksum") }}'
+dbt_observability:
+  models:
+  - name: seeds
+    description: Dimension model that contains data about seeds.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: database_name
+      description: '{{ doc("database_name") }}'
+    - name: schema_name
+      description: '{{ doc("schema_name") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: package_name
+      description: '{{ doc("package_name") }}'
+    - name: path
+      description: '{{ doc("path") }}'
+    - name: checksum
+      description: '{{ doc("checksum") }}'

--- a/models/sources/snapshots.yml
+++ b/models/sources/snapshots.yml
@@ -1,28 +1,28 @@
 version: 2
-
-models:
-- name: snapshots
-  description: Dimension model that contains data about snapshots.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: database_name
-    description: '{{ doc("database_name") }}'
-  - name: schema_name
-    description: '{{ doc("schema_name") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: depends_on_nodes
-    description: '{{ doc("depends_on_nodes") }}'
-  - name: package_name
-    description: '{{ doc("package_name") }}'
-  - name: path
-    description: '{{ doc("path") }}'
-  - name: checksum
-    description: '{{ doc("checksum") }}'
-  - name: strategy
-    description: '{{ doc("strategy") }}'
+dbt_observability:
+  models:
+  - name: snapshots
+    description: Dimension model that contains data about snapshots.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: database_name
+      description: '{{ doc("database_name") }}'
+    - name: schema_name
+      description: '{{ doc("schema_name") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: depends_on_nodes
+      description: '{{ doc("depends_on_nodes") }}'
+    - name: package_name
+      description: '{{ doc("package_name") }}'
+    - name: path
+      description: '{{ doc("path") }}'
+    - name: checksum
+      description: '{{ doc("checksum") }}'
+    - name: strategy
+      description: '{{ doc("strategy") }}'

--- a/models/sources/sources.yml
+++ b/models/sources/sources.yml
@@ -1,28 +1,28 @@
 version: 2
-
-models:
-- name: sources
-  description: Dimension model that contains data about sources.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: database_name
-    description: '{{ doc("database_name") }}'
-  - name: schema_name
-    description: '{{ doc("schema_name") }}'
-  - name: source_name
-    description: '{{ doc("source_name") }}'
-  - name: loader
-    description: '{{ doc("loader") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: identifier
-    description: '{{ doc("identifier") }}'
-  - name: loaded_at_field
-    description: '{{ doc("loaded_at_field") }}'
-  - name: freshness
-    description: '{{ doc("freshness") }}'
+dbt_observability:
+  models:
+  - name: sources
+    description: Dimension model that contains data about sources.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: database_name
+      description: '{{ doc("database_name") }}'
+    - name: schema_name
+      description: '{{ doc("schema_name") }}'
+    - name: source_name
+      description: '{{ doc("source_name") }}'
+    - name: loader
+      description: '{{ doc("loader") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: identifier
+      description: '{{ doc("identifier") }}'
+    - name: loaded_at_field
+      description: '{{ doc("loaded_at_field") }}'
+    - name: freshness
+      description: '{{ doc("freshness") }}'

--- a/models/sources/tests.yml
+++ b/models/sources/tests.yml
@@ -1,24 +1,24 @@
 version: 2
-
-models:
-- name: tests
-  description: Dimension model that contains data about tests.
-  columns:
-  - name: command_invocation_id
-    description: '{{ doc("command_invocation_id") }}'
-  - name: node_id
-    description: '{{ doc("node_id") }}'
-  - name: run_started_at
-    description: '{{ doc("run_started_at") }}'
-  - name: name
-    description: '{{ doc("name") }}'
-  - name: depends_on_nodes
-    description: '{{ doc("depends_on_nodes") }}'
-  - name: package_name
-    description: '{{ doc("package_name") }}'
-  - name: test_path
-    description: '{{ doc("test_path") }}'
-  - name: tags
-    description: '{{ doc("tags") }}'
-  - name: test_metadata
-    description: ''
+dbt_observability:
+  models:
+  - name: tests
+    description: Dimension model that contains data about tests.
+    columns:
+    - name: command_invocation_id
+      description: '{{ doc("command_invocation_id") }}'
+    - name: node_id
+      description: '{{ doc("node_id") }}'
+    - name: run_started_at
+      description: '{{ doc("run_started_at") }}'
+    - name: name
+      description: '{{ doc("name") }}'
+    - name: depends_on_nodes
+      description: '{{ doc("depends_on_nodes") }}'
+    - name: package_name
+      description: '{{ doc("package_name") }}'
+    - name: test_path
+      description: '{{ doc("test_path") }}'
+    - name: tags
+      description: '{{ doc("tags") }}'
+    - name: test_metadata
+      description: ''

--- a/models/staging/staging.yml
+++ b/models/staging/staging.yml
@@ -1,36 +1,36 @@
 version: 2
-
-models:
-  - name: stg_column
-    meta:
-      hidden: true
-  - name: stg_date
-    meta:
-      hidden: true
-  - name: stg_execution
-    meta:
-      hidden: true
-  - name: stg_exposure
-    meta:
-      hidden: true
-  - name: stg_invocation
-    meta:
-      hidden: true
-  - name: stg_metric
-    meta:
-      hidden: true
-  - name: stg_model
-    meta:
-      hidden: true
-  - name: stg_seed
-    meta:
-      hidden: true
-  - name: stg_snapshot
-    meta:
-      hidden: true
-  - name: stg_source
-    meta:
-      hidden: true
-  - name: stg_test
-    meta:
-      hidden: true
+dbt_observability:
+  models:
+    - name: stg_column
+      meta:
+        hidden: true
+    - name: stg_date
+      meta:
+        hidden: true
+    - name: stg_execution
+      meta:
+        hidden: true
+    - name: stg_exposure
+      meta:
+        hidden: true
+    - name: stg_invocation
+      meta:
+        hidden: true
+    - name: stg_metric
+      meta:
+        hidden: true
+    - name: stg_model
+      meta:
+        hidden: true
+    - name: stg_seed
+      meta:
+        hidden: true
+    - name: stg_snapshot
+      meta:
+        hidden: true
+    - name: stg_source
+      meta:
+        hidden: true
+    - name: stg_test
+      meta:
+        hidden: true

--- a/models/views/schema_changes.yml
+++ b/models/views/schema_changes.yml
@@ -1,58 +1,59 @@
 version: 2
-models:
-- name: schema_changes
-  description: ''
-  meta:
-    label: Schema Changes
-    display_index: 1
-  columns:
-  - name: node_id
+dbt_observability:
+  models:
+  - name: schema_changes
     description: ''
-    data_type: text
     meta:
-      label: Node ID
-  - name: resource_type
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Type
-  - name: project
-    description: ''
-    data_type: text
-    meta:
-      label: Project
-  - name: resource_name
-    description: ''
-    data_type: text
-    meta:
-      label: Resource Name
-  - name: change
-    description: ''
-    data_type: text
-    meta:
-      label: Change
-  - name: column_name
-    description: ''
-    data_type: text
-    meta:
-      label: Column Name
-  - name: data_type
-    description: ''
-    data_type: text
-    meta:
-      label: Data Type
-  - name: pre_data_type
-    description: ''
-    data_type: text
-    meta:
-      label: Pre Data Type
-  - name: detected_at
-    description: ''
-    data_type: timestamp
-    meta:
-      label: Detected At
-      hidden: false
-      datatype: date
-      format:
-        type: date
-        pattern: YYYY-MM-DD HH:mm:ss
+      label: Schema Changes
+      display_index: 1
+    columns:
+    - name: node_id
+      description: ''
+      data_type: text
+      meta:
+        label: Node ID
+    - name: resource_type
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Type
+    - name: project
+      description: ''
+      data_type: text
+      meta:
+        label: Project
+    - name: resource_name
+      description: ''
+      data_type: text
+      meta:
+        label: Resource Name
+    - name: change
+      description: ''
+      data_type: text
+      meta:
+        label: Change
+    - name: column_name
+      description: ''
+      data_type: text
+      meta:
+        label: Column Name
+    - name: data_type
+      description: ''
+      data_type: text
+      meta:
+        label: Data Type
+    - name: pre_data_type
+      description: ''
+      data_type: text
+      meta:
+        label: Pre Data Type
+    - name: detected_at
+      description: ''
+      data_type: timestamp
+      meta:
+        label: Detected At
+        hidden: false
+        datatype: date
+        format:
+          type: date
+          pattern: YYYY-MM-DD HH:mm:ss


### PR DESCRIPTION
This PR adds the `dbt_observability` namespace to all model definitions in order to properly separate out the refs of this package and refs of the project that it may be installed in, i.e. dim_date in this package will not conflict with the main project's own dim_date model