### PR TITLE
only error if source rowcount is below average by more than the threhold

### DIFF
--- a/macros/no_anomoly.sql
+++ b/macros/no_anomoly.sql
@@ -22,7 +22,7 @@ select
 from curr
 left outer join hist
     on 1 = 1
-where abs(rowcount_diff_pct)
-    > {{ var('dbt_observability:rowcount_diff_threshold_pct', '.05') }}
+where rowcount_diff_pct
+    < {{ var('dbt_observability:rowcount_diff_threshold_pct', '-.05') }}
 
 {% endtest %}


### PR DESCRIPTION
This PR updates the logic in the `no_anomaly` test to only error if the source row counts are _below_ the project's threshold