### PR TITLE
use fully-qualified sources table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ vars:
   "dbt_observability:path": "models/marts/" # optional, which paths should observability monitor. must be in the form of "dbt_observability:path": "path/subpath/" - default is `None`, will run on all paths in the project
   "dbt_observability:materialization": ["table"] # optional, which model materialization should observability run on. must be array of "table", "view", "incremental", "ephemeral" - default is ["table"]
   "dbt_observability:track_source_rowcounts": false # optional, track source rowcounts - default is false [depending on your dbms, this can be slow and resource intensive as it may require a full table scan if the dbms does not store rowcounts in information_schema.tables]
-  "dbt_observability:rowcount_diff_threshold_pct": .05 # optional, set threshold for no_anomoly test (see below)
+  "dbt_observability:rowcount_diff_threshold_pct": .05 # optional, set threshold for no_anomaly test (see below)
 ...
 
 models:
@@ -107,7 +107,7 @@ vars:
 
 ### dbt Tests
 
-Projects can use the `no_anomoly` test on source tables in their sources.yml. The test will check if the difference between the current source table rowcount and the average of all previous observed rowcounts is significant enough to raise an error/warning. Set the `dbt_observability:rowcount_diff_threshold_pct` variable (see above) to override the default threshold of .05 (i.e. a 5% difference in rowcount).
+Projects can use the `no_anomaly` test on source tables in their sources.yml. The test will check if the difference between the current source table rowcount and the average of all previous observed rowcounts is significant enough to raise an error/warning. Set the `dbt_observability:rowcount_diff_threshold_pct` variable (see above) to override the default threshold of .05 (i.e. a 5% difference in rowcount).
 
 ```yml
 sources:
@@ -115,7 +115,7 @@ sources:
     tables:
       - name: some_source_table
         tests:
-          - dbt_observability.no_anomoly:
+          - dbt_observability.no_anomaly:
               config:
                 severity: error
 ```

--- a/macros/no_anomaly.sql
+++ b/macros/no_anomaly.sql
@@ -1,9 +1,9 @@
-{% test no_anomoly(model) %}
+{% test no_anomaly(model) %}
 
 with
     hist as (
         select avg(total_rowcount) as average_rowcount
-        from {{ ref('sources') }} -- {{ database }}.{{ target.schema }}_observability.sources
+        from {{ database }}.{{ target.schema }}_observability.sources
         where {{ dbt.concat(['\'"\'', "database_name", '\'"."\'' , "source_name", '\'"."\'', "identifier", '\'"\'']) }} = '{{ model }}'
             and coalesce(total_rowcount, 0) > 0
     ),

--- a/macros/no_anomaly.sql
+++ b/macros/no_anomaly.sql
@@ -3,7 +3,7 @@
 with
     hist as (
         select avg(total_rowcount) as average_rowcount
-        from {{ database }}.{{ target.schema }}_observability.sources
+         from {{ database }}.{{ target.schema }}_observability.sources  {# we can't use a ref here, see https://github.com/flexanalytics/dbt_observability/issues/32 #}
         where {{ dbt.concat(['\'"\'', "database_name", '\'"."\'' , "source_name", '\'"."\'', "identifier", '\'"\'']) }} = '{{ model }}'
             and coalesce(total_rowcount, 0) > 0
     ),


### PR DESCRIPTION
Fixes #32 
This PR updates the no_anomaly test to use a fully-qualified sources table name. 