### PR TITLE
Remove project name filter

### DIFF
--- a/macros/_get_config_models.sql
+++ b/macros/_get_config_models.sql
@@ -1,6 +1,6 @@
 {% macro get_models_list(graph, path=None, materialization=[]) %}
     {% set models = [] %}
-        {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "model") | selectattr("package_name", "equalto", project_name) %}
+        {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "model") %}
             {% set orig_path = (node.original_file_path | replace('\\', '/')) %}
             {% if path and not materialization %}
                 {% if (path + node.name + ".sql") == orig_path %}

--- a/macros/upload_all_executions.sql
+++ b/macros/upload_all_executions.sql
@@ -1,9 +1,7 @@
 {% macro upload_all_executions(results) -%}
     {% set executions = [] %}
     {% for result in results  %}
-        {% if project_name == result.node.package_name %}
             {% do executions.append(result) %}
-        {% endif %}
     {% endfor %}
     {{ return(adapter.dispatch('get_all_executions_dml_sql', 'dbt_observability')(executions)) }}
 {%- endmacro %}

--- a/macros/upload_columns.sql
+++ b/macros/upload_columns.sql
@@ -96,7 +96,7 @@
         {% for model in new_list -%}
 
             {% set lowerCols = {} %}
-            {% for k, v in model.columns.items()  %}
+            {% for k, v in model.columns.items() %}
                 {% do lowerCols.update({k.lower(): v}) %}
             {% endfor %}
 

--- a/macros/upload_metrics.sql
+++ b/macros/upload_metrics.sql
@@ -1,6 +1,6 @@
 {% macro upload_metrics(graph) -%}
     {% set metrics = [] %}
-    {% for node in graph.metrics.values() | selectattr("package_name", "equalto", project_name) %}
+    {% for node in graph.metrics.values() %}
         {% do metrics.append(node) %}
     {% endfor %}
     {{ return(adapter.dispatch('get_metrics_dml_sql', 'dbt_observability')(metrics)) }}

--- a/macros/upload_seeds.sql
+++ b/macros/upload_seeds.sql
@@ -1,6 +1,6 @@
 {% macro upload_seeds(graph) -%}
     {% set seeds = [] %}
-    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "seed") | selectattr("package_name", "equalto", project_name) %}
+    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "seed") %}
         {% do seeds.append(node) %}
     {% endfor %}
     {{ return(adapter.dispatch('get_seeds_dml_sql', 'dbt_observability')(seeds)) }}

--- a/macros/upload_snapshots.sql
+++ b/macros/upload_snapshots.sql
@@ -1,6 +1,6 @@
 {% macro upload_snapshots(graph) -%}
     {% set snapshots = [] %}
-    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "snapshot") | selectattr("package_name", "equalto", project_name) %}
+    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "snapshot") %}
         {% do snapshots.append(node) %}
     {% endfor %}
     {{ return(adapter.dispatch('get_snapshots_dml_sql', 'dbt_observability')(snapshots)) }}

--- a/macros/upload_tests.sql
+++ b/macros/upload_tests.sql
@@ -1,6 +1,6 @@
 {% macro upload_tests(graph) -%}
     {% set tests = [] %}
-    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "test") | selectattr("package_name", "equalto", project_name) %}
+    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "test") %}
         {% do tests.append(node) %}
     {% endfor %}
     {{ return(adapter.dispatch('get_tests_dml_sql', 'dbt_observability')(tests)) }}


### PR DESCRIPTION
This PR updates the upload macros to remove the filter on `project_name` so that any nodes that were affected by the build are observed. 
Note [the path configuration](https://github.com/flexanalytics/dbt_observability?tab=readme-ov-file#configuration) can still be used to limit the observed nodes. 