### PR TITLE
add redshift string type

### DIFF
--- a/macros/type_helpers.sql
+++ b/macros/type_helpers.sql
@@ -78,6 +78,10 @@
    string
 {% endmacro %}
 
+{% macro redshift__type_string() %}
+   varchar(65535)
+{% endmacro %}
+
 {% macro snowflake__type_string() %}
    varchar(16777216)
 {% endmacro %}


### PR DESCRIPTION
This PR adds `type_string` for redshift to fix an issue where columns were getting created with type `varchar(1)`. 