### PR TITLE
log_observability macro

### DIFF
--- a/macros/adapter_functions.sql
+++ b/macros/adapter_functions.sql
@@ -9,3 +9,10 @@
 {% macro sqlserver__stddev() -%}
     stdev
 {%- endmacro %}
+
+{% macro log_observability() -%}
+  {{ return(adapter.dispatch('log_observability','dbt_observability')()) }}
+{%- endmacro %}
+
+{% macro default__log_observability() -%}
+{%- endmacro %}

--- a/macros/upload_results.sql
+++ b/macros/upload_results.sql
@@ -24,6 +24,8 @@
 
     {% if execute and var('dbt_observability:tracking_enabled', true) and flags.WHICH in ['build','run','test'] %}
 
+        {{ dbt_observability.log_observability() }}
+
         {% do log("Uploading invocations", true) %}
         {% set invocations = dbt_observability.get_relation('invocations') %}
         {% set content_invocations = dbt_observability.upload_invocations() %}


### PR DESCRIPTION
Allow packages to override the log_observability() to put custom logging in before observability does uploads. For example, you can put a URL to a FlexIt report and pass in the invocation Id.