### PR TITLE
Handle potential `None` in rowcounts

### DIFF
--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -50,7 +50,8 @@
                     {%- endset -%}
                 {% endif %}
                 {%- set results = run_query(rowcount_query) -%}
-                {%- set model_rowcount = results.columns[0].values()[0] -%}
+                {%- set raw_value = results.columns[0].values() | first -%}
+                {%- set model_rowcount = 0 if raw_value is none else raw_value -%}
             {% else %}
                 {%- set model_rowcount = 0 -%}
             {% endif %}
@@ -70,7 +71,7 @@
                 '{{ tojson(model.tags) }}', {# tags #}
                 '{{ tojson(model.config.meta) }}', {# meta #}
                 '{{ null if model.description is not defined else adapter.dispatch('escape_singlequote', 'dbt_observability')(model.description) }}', {# description #}
-                {{ 0 if model_rowcount is not defined else model_rowcount }} {# total rowcount #}
+                {{ model_rowcount }}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -93,7 +94,8 @@
                     select count(*) as model_rowcount from {{ model.schema }}.{{ model.name }}
                     {%- endset -%}
                     {%- set results = run_query(rowcount_query) -%}
-                    {%- set model_rowcount = results.columns[0].values()[0] -%}
+                    {%- set raw_value = results.columns[0].values() | first -%}
+                    {%- set model_rowcount = 0 if raw_value is none else raw_value -%}
                 {% else %}
                     {%- set model_rowcount = 0 -%}
                 {% endif %}
@@ -113,7 +115,7 @@
                     {{ tojson(model.tags) }}, {# tags #}
                     parse_json('{{ tojson(model.config.meta) }}'), {# meta #}
                     '{{ null if model.description is not defined else adapter.dispatch('escape_singlequote', 'dbt_observability')(model.description) }}', {# description #}
-                    {{ 0 if model_rowcount is not defined else model_rowcount }} {# total rowcount #}
+                    {{ model_rowcount }} {# total rowcount #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_sources.sql
+++ b/macros/upload_sources.sql
@@ -53,7 +53,8 @@
                     {%- endset -%}
                 {% endif %}
                 {%- set results = run_query(rowcount_query) -%}
-                {%- set source_rowcount = results.columns[0].values()[0] -%}
+                {%- set raw_value = results.columns[0].values() | first -%}
+                {%- set source_rowcount = 0 if raw_value is none else raw_value -%}
 
             {% else %}
 
@@ -101,7 +102,8 @@
                     and lower(table_schema) = lower('{{ source.schema }}')
                 {%- endset -%}
             {%- set results = run_query(rowcount_query) -%}
-            {%- set source_rowcount = results.columns[0].values()[0] -%}
+            {%- set raw_value = results.columns[0].values() | first -%}
+            {%- set source_rowcount = 0 if raw_value is none else raw_value -%}
             {% else %}
                 {%- set source_rowcount = 0 -%}
             {% endif %}
@@ -117,7 +119,7 @@
                     '{{ source.identifier }}', {# identifier #}
                     '{{ adapter.dispatch('escape_singlequote', 'dbt_observability')(source.loaded_at_field) }}', {# loaded_at_field #}
                     parse_json('{{ tojson(source.freshness) }}'), {# freshness #}
-                    {{ 0 if source_rowcount is not defined else source_rowcount }} {# source_rowcount #}
+                    {{ source_rowcount }} {# source_rowcount #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}


### PR DESCRIPTION
The current logic for model_rowcount could potentially result in `None`, and inserts fail if an unquoted `None` (evaluated in the macro as `{{ None }}`) is passed to the insert statement. 

These are the only values in the macro that are unquoted numeric values (`{{ model_rowcount }}` vs `'{{ model.description }}'`) so these should be the only potential broken columns. 