### PR TITLE
Fix multi-schema sources query

### DIFF
--- a/macros/get_columns_content.sql
+++ b/macros/get_columns_content.sql
@@ -62,6 +62,7 @@
         )
                 {%- if not loop.last %} union all {% endif %}
             {% endfor %}
+            {%- if not loop.last %} union all {% endif %}
         {% endfor %}
     {%- endset %}
 


### PR DESCRIPTION
Add `union all` to end of for loop to account for projects with sources from multiple schemas