### PR TITLE
add optional project name to upload_results

### DIFF
--- a/macros/upload_results.sql
+++ b/macros/upload_results.sql
@@ -15,7 +15,8 @@
 {% endmacro %}
 
 
-{% macro upload_results(results) -%}
+{% macro upload_results(results, project=project_name) -%}
+  {% if project == project_name %}
     {% set upload_limit = 300 if target.type == 'bigquery' else 1000 %}
     {% set path = var('dbt_observability:path', None) %}
     {% set materialization = var('dbt_observability:materialization', ['table','incremental']) %}
@@ -157,4 +158,5 @@
 
     {% endif %}
     {% endif %}
+  {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
This PR adds an optional `project` argument (defaulted to dbt's globally available `project_name`) to the `upload_results` macro. This allows users to avoid imported packages running observability's on-run-end hook by passing in a hard-coded project name to the hook. Since `project_name` resolves to the root project even in imported packages' on-run-end hooks, this was the best workaround. 
fixes #63 