### PR TITLE
Add additional columns to test upload

### DIFF
--- a/macros/upload_tests.sql
+++ b/macros/upload_tests.sql
@@ -27,7 +27,19 @@
             {{ adapter.dispatch('parse_json', 'dbt_observability')(adapter.dispatch('column_identifier', 'dbt_observability')(9)) }},
             {{ adapter.dispatch('column_identifier', 'dbt_observability')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_observability')(11) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_observability')(12) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(12) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(13) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(14) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(15) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(16) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(17) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(18) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(19) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(20) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(21) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(22) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(23) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(24) }}
         from values
 
         {% endif %}
@@ -38,8 +50,30 @@
             {% else %}
                 {% set test_description = "" %}
             {% endif %}
-            {% set test_column_name = test.column_name if test.column_name else "" %}
-            {% set test_attached_node = test.attached_node if (test.attached_node is defined and test.attached_node) else "" %}
+            {# test_metadata is a TestMetadata object (not a dict) -- use attribute
+               access (Jinja resolves it for objects and dicts alike); kwargs is a dict #}
+            {% set metadata = test.test_metadata if test.test_metadata is defined and test.test_metadata else none %}
+            {% set kwargs = metadata.kwargs if metadata else {} %}
+            {% set combination = kwargs.get('combination_of_columns') %}
+            {% set test_attached_node = test.attached_node if test.attached_node is defined else none %}
+            {% set test_package = metadata.namespace if metadata else none %}
+            {% set test_type_name = metadata.name if metadata else none %}
+            {# model is a raw get_where_subquery(ref()) expression -- keep just the model name #}
+            {% set test_model = kwargs.get('model') %}
+            {% set test_model_names = modules.re.findall("'([^']*)'", test_model | string) if test_model else [] %}
+            {% set test_model = test_model_names[-1] if test_model_names else test_model %}
+            {% set test_combination = combination | join(', ') if combination else none %}
+            {# to / compare_model is a raw ref()/source() expression -- keep just the model name #}
+            {% set test_to_model = kwargs.get('to') or kwargs.get('compare_model') %}
+            {% set test_to_model_names = modules.re.findall("'([^']*)'", test_to_model | string) if test_to_model else [] %}
+            {% set test_to_model = test_to_model_names[-1] if test_to_model_names else test_to_model %}
+            {% set test_column_value = kwargs.get('value') %}
+            {% set test_min_value = kwargs.get('min_value') %}
+            {% set test_max_value = kwargs.get('max_value') %}
+            {% set test_from_condition = kwargs.get('from_condition') %}
+            {% set test_to_field = kwargs.get('field') %}
+            {% set test_to_condition = kwargs.get('to_condition') %}
+            {% set test_expression = kwargs.get('expression') %}
             {# Create a row for each test #}
             (
                 '{{ invocation_id }}', {# command_invocation_id #}
@@ -52,8 +86,20 @@
                 '{{ tojson(test.tags) }}', {# tags #}
                 '{{ null if test.test_metadata is not defined else adapter.dispatch('escape_singlequote', 'dbt_observability')(tojson(test.test_metadata)) }}', {# test.test_metadata #}
                 '{{ test_description }}', {# description #}
-                '{{ test_column_name }}', {# column_name #}
-                '{{ test_attached_node }}' {# attached_node #}
+                '{{ null if test.column_name is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test.column_name | string) }}', {# column_name #}
+                '{{ null if test_attached_node is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_attached_node | string) }}', {# attached_node #}
+                '{{ null if test_package is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_package | string) }}', {# test_package #}
+                '{{ null if test_type_name is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_type_name | string) }}', {# test_name #}
+                '{{ null if test_model is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_model | string) }}', {# test_model #}
+                '{{ null if test_combination is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_combination | string) }}', {# test_combination_of_columns #}
+                '{{ null if test_column_value is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_column_value | string) }}', {# test_column_value #}
+                '{{ null if test_min_value is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_min_value | string) }}', {# test_column_min_value #}
+                '{{ null if test_max_value is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_max_value | string) }}', {# test_column_max_value #}
+                '{{ null if test_from_condition is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_from_condition | string) }}', {# test_relationship_from_model_condition #}
+                '{{ null if test_to_model is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_to_model | string) }}', {# test_to_model #}
+                '{{ null if test_to_field is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_to_field | string) }}', {# test_relationship_to_field #}
+                '{{ null if test_to_condition is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_to_condition | string) }}', {# test_relationship_to_model_condition #}
+                '{{ null if test_expression is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_expression | string) }}' {# test_column_expression #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -73,8 +119,30 @@
                 {% else %}
                     {% set test_description = "" %}
                 {% endif %}
-                {% set test_column_name = test.column_name if test.column_name else "" %}
-                {% set test_attached_node = test.attached_node if (test.attached_node is defined and test.attached_node) else "" %}
+                {# test_metadata is a TestMetadata object (not a dict) -- use attribute
+                   access (Jinja resolves it for objects and dicts alike); kwargs is a dict #}
+                {% set metadata = test.test_metadata if test.test_metadata is defined and test.test_metadata else none %}
+                {% set kwargs = metadata.kwargs if metadata else {} %}
+                {% set combination = kwargs.get('combination_of_columns') %}
+                {% set test_attached_node = test.attached_node if test.attached_node is defined else none %}
+                {% set test_package = metadata.namespace if metadata else none %}
+                {% set test_type_name = metadata.name if metadata else none %}
+                {# model is a raw get_where_subquery(ref()) expression -- keep just the model name #}
+                {% set test_model = kwargs.get('model') %}
+                {% set test_model_names = modules.re.findall("'([^']*)'", test_model | string) if test_model else [] %}
+                {% set test_model = test_model_names[-1] if test_model_names else test_model %}
+                {% set test_combination = combination | join(', ') if combination else none %}
+                {# to / compare_model is a raw ref()/source() expression -- keep just the model name #}
+                {% set test_to_model = kwargs.get('to') or kwargs.get('compare_model') %}
+                {% set test_to_model_names = modules.re.findall("'([^']*)'", test_to_model | string) if test_to_model else [] %}
+                {% set test_to_model = test_to_model_names[-1] if test_to_model_names else test_to_model %}
+                {% set test_column_value = kwargs.get('value') %}
+                {% set test_min_value = kwargs.get('min_value') %}
+                {% set test_max_value = kwargs.get('max_value') %}
+                {% set test_from_condition = kwargs.get('from_condition') %}
+                {% set test_to_field = kwargs.get('field') %}
+                {% set test_to_condition = kwargs.get('to_condition') %}
+                {% set test_expression = kwargs.get('expression') %}
                 (
                     '{{ invocation_id }}', {# command_invocation_id #}
                     '{{ test.unique_id }}', {# node_id #}
@@ -86,8 +154,20 @@
                     {{ tojson(test.tags) }}, {# tags #}
                     parse_json('{{ tojson(test.test_metadata) }}'), {# test_metadata #}
                     '{{ test_description }}', {# description #}
-                    '{{ test_column_name }}', {# column_name #}
-                    '{{ test_attached_node }}' {# attached_node #}
+                    '{{ null if test.column_name is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test.column_name | string) }}', {# column_name #}
+                    '{{ null if test_attached_node is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_attached_node | string) }}', {# attached_node #}
+                    '{{ null if test_package is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_package | string) }}', {# test_package #}
+                    '{{ null if test_type_name is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_type_name | string) }}', {# test_name #}
+                    '{{ null if test_model is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_model | string) }}', {# test_model #}
+                    '{{ null if test_combination is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_combination | string) }}', {# test_combination_of_columns #}
+                    '{{ null if test_column_value is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_column_value | string) }}', {# test_column_value #}
+                    '{{ null if test_min_value is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_min_value | string) }}', {# test_column_min_value #}
+                    '{{ null if test_max_value is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_max_value | string) }}', {# test_column_max_value #}
+                    '{{ null if test_from_condition is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_from_condition | string) }}', {# test_relationship_from_model_condition #}
+                    '{{ null if test_to_model is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_to_model | string) }}', {# test_to_model #}
+                    '{{ null if test_to_field is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_to_field | string) }}', {# test_relationship_to_field #}
+                    '{{ null if test_to_condition is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_to_condition | string) }}', {# test_relationship_to_model_condition #}
+                    '{{ null if test_expression is none else adapter.dispatch('escape_singlequote', 'dbt_observability')(test_expression | string) }}' {# test_column_expression #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_tests.sql
+++ b/macros/upload_tests.sql
@@ -25,7 +25,9 @@
             {{ adapter.dispatch('column_identifier', 'dbt_observability')(7) }},
             {{ adapter.dispatch('parse_json', 'dbt_observability')(adapter.dispatch('column_identifier', 'dbt_observability')(8)) }},
             {{ adapter.dispatch('parse_json', 'dbt_observability')(adapter.dispatch('column_identifier', 'dbt_observability')(9)) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_observability')(10) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(10) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(11) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_observability')(12) }}
         from values
 
         {% endif %}
@@ -36,6 +38,8 @@
             {% else %}
                 {% set test_description = "" %}
             {% endif %}
+            {% set test_column_name = test.column_name if test.column_name else "" %}
+            {% set test_attached_node = test.attached_node if (test.attached_node is defined and test.attached_node) else "" %}
             {# Create a row for each test #}
             (
                 '{{ invocation_id }}', {# command_invocation_id #}
@@ -47,7 +51,9 @@
                 '{{ test.original_file_path | replace('\\', '\\\\') }}', {# test_path #}
                 '{{ tojson(test.tags) }}', {# tags #}
                 '{{ null if test.test_metadata is not defined else adapter.dispatch('escape_singlequote', 'dbt_observability')(tojson(test.test_metadata)) }}', {# test.test_metadata #}
-                '{{ test_description }}' {# description #}
+                '{{ test_description }}', {# description #}
+                '{{ test_column_name }}', {# column_name #}
+                '{{ test_attached_node }}' {# attached_node #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -67,6 +73,8 @@
                 {% else %}
                     {% set test_description = "" %}
                 {% endif %}
+                {% set test_column_name = test.column_name if test.column_name else "" %}
+                {% set test_attached_node = test.attached_node if (test.attached_node is defined and test.attached_node) else "" %}
                 (
                     '{{ invocation_id }}', {# command_invocation_id #}
                     '{{ test.unique_id }}', {# node_id #}
@@ -77,7 +85,9 @@
                     '{{ test.original_file_path | replace('\\', '\\\\') }}', {# test_path #}
                     {{ tojson(test.tags) }}, {# tags #}
                     parse_json('{{ tojson(test.test_metadata) }}'), {# test_metadata #}
-                    '{{ test_description }}' {# description #}
+                    '{{ test_description }}', {# description #}
+                    '{{ test_column_name }}', {# column_name #}
+                    '{{ test_attached_node }}' {# attached_node #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/models/sources/tests.sql
+++ b/models/sources/tests.sql
@@ -19,6 +19,8 @@ select
     cast(null as {{ type_string() }}) as test_path,
     cast(null as {{ type_array() }}) as tags,
     cast(null as {{ type_json() }}) as test_metadata,
-    cast(null as {{ type_string() }}) as description
+    cast(null as {{ type_string() }}) as description,
+    cast(null as {{ type_string() }}) as column_name,
+    cast(null as {{ type_string() }}) as attached_node
 from dummy_cte
 where 1 = 0

--- a/models/sources/tests.sql
+++ b/models/sources/tests.sql
@@ -21,6 +21,19 @@ select
     cast(null as {{ type_json() }}) as test_metadata,
     cast(null as {{ type_string() }}) as description,
     cast(null as {{ type_string() }}) as column_name,
-    cast(null as {{ type_string() }}) as attached_node
+    cast(null as {{ type_string() }}) as attached_node,
+    -- parsed from test_metadata at upload time (see upload_tests.sql)
+    cast(null as {{ type_string() }}) as test_package,
+    cast(null as {{ type_string() }}) as test_name,
+    cast(null as {{ type_string() }}) as test_model,
+    cast(null as {{ type_string() }}) as test_combination_of_columns,
+    cast(null as {{ type_string() }}) as test_column_value,
+    cast(null as {{ type_string() }}) as test_column_min_value,
+    cast(null as {{ type_string() }}) as test_column_max_value,
+    cast(null as {{ type_string() }}) as test_relationship_from_model_condition,
+    cast(null as {{ type_string() }}) as test_to_model,
+    cast(null as {{ type_string() }}) as test_relationship_to_field,
+    cast(null as {{ type_string() }}) as test_relationship_to_model_condition,
+    cast(null as {{ type_string() }}) as test_column_expression
 from dummy_cte
 where 1 = 0

--- a/models/sources/tests.yml
+++ b/models/sources/tests.yml
@@ -28,3 +28,27 @@ dbt_observability:
       description: The column the test is attached to in the schema yml, when the test is defined under a column. Null for model-level and singular tests.
     - name: attached_node
       description: The node_id of the model, source, seed, or snapshot the test is attached to. Available on dbt 1.6+; null otherwise.
+    - name: test_package
+      description: Package namespace the generic test comes from (test_metadata.namespace), e.g. dbt_utils. Null for singular tests.
+    - name: test_name
+      description: Generic test type (test_metadata.name), e.g. not_null, unique, relationships. Null for singular tests.
+    - name: test_model
+      description: Raw ref()/source() expression the test is attached to (test_metadata.kwargs.model).
+    - name: test_combination_of_columns
+      description: Comma-separated columns for composite tests, e.g. unique_combination_of_columns (test_metadata.kwargs.combination_of_columns).
+    - name: test_column_value
+      description: Expected value for accepted_values-style tests (test_metadata.kwargs.value).
+    - name: test_column_min_value
+      description: Minimum bound for range tests (test_metadata.kwargs.min_value). Stored as text; cast downstream.
+    - name: test_column_max_value
+      description: Maximum bound for range tests (test_metadata.kwargs.max_value). Stored as text; cast downstream.
+    - name: test_relationship_from_model_condition
+      description: from_condition filter on a relationships test (test_metadata.kwargs.from_condition).
+    - name: test_to_model
+      description: Target model of a relationships test (test_metadata.kwargs.to / compare_model).
+    - name: test_relationship_to_field
+      description: Target field of a relationships test (test_metadata.kwargs.field).
+    - name: test_relationship_to_model_condition
+      description: to_condition filter on a relationships test (test_metadata.kwargs.to_condition).
+    - name: test_column_expression
+      description: Expression for expression-style tests (test_metadata.kwargs.expression).

--- a/models/sources/tests.yml
+++ b/models/sources/tests.yml
@@ -24,3 +24,7 @@ dbt_observability:
       description: '{{ doc("tags") }}'
     - name: test_metadata
       description: ''
+    - name: column_name
+      description: The column the test is attached to in the schema yml, when the test is defined under a column. Null for model-level and singular tests.
+    - name: attached_node
+      description: The node_id of the model, source, seed, or snapshot the test is attached to. Available on dbt 1.6+; null otherwise.


### PR DESCRIPTION
This PR updates the upload_test functionality to capture test column_name/attached_node and parse test_metadata into first-class columns

Test rows in the `tests` source table previously carried only the raw `test_metadata` JSON blob, forcing every downstream consumer to parse it per-adapter to learn anything about a test (what column it covers, what model it relates to, etc.). This moves that work to the producer, once, so the parsed attributes are first-class columns that any consumer reads directly.

Two sources of new columns:

1. **Manifest first-class fields** (read straight off the test node):
   - `column_name`: the column a test is attached to (set for every column-level test, regardless of how its kwargs are named).
   - `attached_node`: the node the test is defined under (dbt 1.6+). Disambiguates the primary node for relationship tests, which depend on two models.

2. **Parsed from `test_metadata` at upload time** (Jinja attribute access on the `TestMetadata` object: `metadata.name`/`metadata.kwargs`:

`test_name`, `test_package`, `test_model`, `test_combination_of_columns`, `test_column_value`, `test_column_min_value`, `test_column_max_value`, `test_relationship_from_model_condition`, `test_to_model`, `test_relationship_to_field`, `test_relationship_to_model_condition`, `test_column_expression`.

`test_model` / `test_to_model` are reduced to just the model name (extracted from the raw `ref()` / `source()` expression via `modules.re`). The raw `test_metadata` JSON is **retained** so arbitrary / third-party test kwargs are never lost. First-class columns cover only the common, standard dbt-core + dbt_utils kwargs.

