### PR TITLE
Fix deprecation warnings for dbt-core.v11

### DIFF
--- a/models/sources/all_executions.yml
+++ b/models/sources/all_executions.yml
@@ -1,33 +1,32 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: all_executions
     description: Contains data about all resource executions.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: was_full_refresh
-      description: '{{ doc("was_full_refresh") }}'
-    - name: thread_id
-      description: '{{ doc("thread_id") }}'
-    - name: status
-      description: '{{ doc("status") }}'
-    - name: compile_started_at
-      description: '{{ doc("compile_started_at") }}'
-    - name: query_completed_at
-      description: '{{ doc("query_completed_at") }}'
-    - name: total_node_runtime
-      description: '{{ doc("total_node_runtime") }}'
-    - name: materialization
-      description: '{{ doc("materialization") }}'
-    - name: schema_name
-      description: '{{ doc("schema_name") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: resource_type
-      description: '{{ doc("resource_type") }}'
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: was_full_refresh
+        description: '{{ doc("was_full_refresh") }}'
+      - name: thread_id
+        description: '{{ doc("thread_id") }}'
+      - name: status
+        description: '{{ doc("status") }}'
+      - name: compile_started_at
+        description: '{{ doc("compile_started_at") }}'
+      - name: query_completed_at
+        description: '{{ doc("query_completed_at") }}'
+      - name: total_node_runtime
+        description: '{{ doc("total_node_runtime") }}'
+      - name: materialization
+        description: '{{ doc("materialization") }}'
+      - name: schema_name
+        description: '{{ doc("schema_name") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: resource_type
+        description: '{{ doc("resource_type") }}'
 

--- a/models/sources/columns.yml
+++ b/models/sources/columns.yml
@@ -1,57 +1,64 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: columns
-    meta:
-      label: Columns
+    config:
+      meta:
+        label: Columns
     columns:
-    - name: command_invocation_id
-      description: ''
-      meta:
-        label: Command Invocation Id
-    - name: node_id
-      description: ''
-      meta:
-        label: Node Id
-    - name: column_name
-      description: ''
-      meta:
-        label: Column Name
-    - name: data_type
-      description: ''
-      meta:
-        label: Data Type
-    - name: tags
-      description: ''
-      meta:
-        label: Tags
-    - name: meta
-      description: ''
-      meta:
-        label: Meta
-    - name: description
-      description: ''
-      meta:
-        label: Description
-    - name: is_documented
-      description: ''
-    - name: row_count
-      description: ''
-    - name: row_distinct
-      description: ''
-    - name: row_null
-      description: ''
-    - name: row_min
-      description: ''
-    - name: row_max
-      description: ''
-    - name: row_avg
-      description: ''
-    - name: row_sum
-      description: ''
-    - name: row_stdev
-      description: ''
-    - name: is_metric
-      description: ''
-    - name: column_values
+      - name: command_invocation_id
+        description: ''
+        config:
+          meta:
+            label: Command Invocation Id
+      - name: node_id
+        description: ''
+        config:
+          meta:
+            label: Node Id
+      - name: column_name
+        description: ''
+        config:
+          meta:
+            label: Column Name
+      - name: data_type
+        description: ''
+        config:
+          meta:
+            label: Data Type
+      - name: tags
+        description: ''
+        config:
+          meta:
+            label: Tags
+      - name: meta
+        description: ''
+        config:
+          meta:
+            label: Meta
+      - name: description
+        description: ''
+        config:
+          meta:
+            label: Description
+      - name: is_documented
+        description: ''
+      - name: row_count
+        description: ''
+      - name: row_distinct
+        description: ''
+      - name: row_null
+        description: ''
+      - name: row_min
+        description: ''
+      - name: row_max
+        description: ''
+      - name: row_avg
+        description: ''
+      - name: row_sum
+        description: ''
+      - name: row_stdev
+        description: ''
+      - name: is_metric
+        description: ''
+      - name: column_values
     description: ''

--- a/models/sources/exposures.yml
+++ b/models/sources/exposures.yml
@@ -1,30 +1,29 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: exposures
     description: Dimension model that contains data about exposures.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: type
-      description: '{{ doc("type") }}'
-    - name: owner
-      description: '{{ doc("owner") }}'
-    - name: maturity
-      description: '{{ doc("maturity") }}'
-    - name: path
-      description: '{{ doc("path") }}'
-    - name: description
-      description: '{{ doc("description") }}'
-    - name: url
-      description: '{{ doc("url") }}'
-    - name: package_name
-      description: '{{ doc("package_name") }}'
-    - name: depends_on_nodes
-      description: '{{ doc("depends_on_nodes") }}'
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: type
+        description: '{{ doc("type") }}'
+      - name: owner
+        description: '{{ doc("owner") }}'
+      - name: maturity
+        description: '{{ doc("maturity") }}'
+      - name: path
+        description: '{{ doc("path") }}'
+      - name: description
+        description: '{{ doc("description") }}'
+      - name: url
+        description: '{{ doc("url") }}'
+      - name: package_name
+        description: '{{ doc("package_name") }}'
+      - name: depends_on_nodes
+        description: '{{ doc("depends_on_nodes") }}'

--- a/models/sources/invocations.yml
+++ b/models/sources/invocations.yml
@@ -1,42 +1,41 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: invocations
     description: ''
     columns:
-    - name: command_invocation_id
-      description: ''
-    - name: dbt_version
-      description: ''
-    - name: project_name
-      description: ''
-    - name: run_started_at
-      description: ''
-    - name: dbt_command
-      description: ''
-    - name: full_refresh_flag
-      description: ''
-    - name: target_type
-      description: ''
-    - name: target_profile_name
-      description: ''
-    - name: target_name
-      description: ''
-    - name: target_schema
-      description: ''
-    - name: target_threads
-      description: ''
-    - name: dbt_cloud_project_id
-      description: ''
-    - name: dbt_cloud_job_id
-      description: ''
-    - name: dbt_cloud_run_id
-      description: ''
-    - name: dbt_cloud_run_reason_category
-      description: ''
-    - name: dbt_cloud_run_reason
-      description: ''
-    - name: env_vars
-      description: ''
-    - name: dbt_vars
-      description: ''
+      - name: command_invocation_id
+        description: ''
+      - name: dbt_version
+        description: ''
+      - name: project_name
+        description: ''
+      - name: run_started_at
+        description: ''
+      - name: dbt_command
+        description: ''
+      - name: full_refresh_flag
+        description: ''
+      - name: target_type
+        description: ''
+      - name: target_profile_name
+        description: ''
+      - name: target_name
+        description: ''
+      - name: target_schema
+        description: ''
+      - name: target_threads
+        description: ''
+      - name: dbt_cloud_project_id
+        description: ''
+      - name: dbt_cloud_job_id
+        description: ''
+      - name: dbt_cloud_run_id
+        description: ''
+      - name: dbt_cloud_run_reason_category
+        description: ''
+      - name: dbt_cloud_run_reason
+        description: ''
+      - name: env_vars
+        description: ''
+      - name: dbt_vars
+        description: ''

--- a/models/sources/metrics.yml
+++ b/models/sources/metrics.yml
@@ -1,34 +1,33 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: metrics
     description: ''
     columns:
-    - name: command_invocation_id
-      description: ''
-    - name: unique_id
-      description: ''
-    - name: name
-      description: ''
-    - name: label
-      description: ''
-    - name: model
-      description: ''
-    - name: expression
-      description: ''
-    - name: calculation_method
-      description: ''
-    - name: filters
-      description: ''
-    - name: time_grains
-      description: ''
-    - name: dimensions
-      description: ''
-    - name: package_name
-      description: ''
-    - name: meta
-      description: ''
-    - name: depends_on_nodes
-      description: ''
-    - name: description
-      description: ''
+      - name: command_invocation_id
+        description: ''
+      - name: unique_id
+        description: ''
+      - name: name
+        description: ''
+      - name: label
+        description: ''
+      - name: model
+        description: ''
+      - name: expression
+        description: ''
+      - name: calculation_method
+        description: ''
+      - name: filters
+        description: ''
+      - name: time_grains
+        description: ''
+      - name: dimensions
+        description: ''
+      - name: package_name
+        description: ''
+      - name: meta
+        description: ''
+      - name: depends_on_nodes
+        description: ''
+      - name: description
+        description: ''

--- a/models/sources/models.yml
+++ b/models/sources/models.yml
@@ -1,38 +1,38 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: models
     description: Dimension that contains data about models.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: database_name
-      description: '{{ doc("database_name") }}'
-    - name: schema_name
-      description: '{{ doc("schema_name") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: depends_on_nodes
-      description: '{{ doc("depends_on_nodes") }}'
-    - name: package_name
-      description: '{{ doc("package_name") }}'
-    - name: path
-      description: '{{ doc("path") }}'
-    - name: checksum
-      description: '{{ doc("checksum") }}'
-    - name: materialization
-      description: '{{ doc("materialization") }}'
-    - name: tags
-      description: '{{ doc("tags") }}'
-    - name: meta
-      description: '{{ doc("meta") }}'
-    - name: description
-      description: ''
-      meta:
-        label: Description
-    - name: total_rowcount
-      description: 'Total rowcount for the model'
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: database_name
+        description: '{{ doc("database_name") }}'
+      - name: schema_name
+        description: '{{ doc("schema_name") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: depends_on_nodes
+        description: '{{ doc("depends_on_nodes") }}'
+      - name: package_name
+        description: '{{ doc("package_name") }}'
+      - name: path
+        description: '{{ doc("path") }}'
+      - name: checksum
+        description: '{{ doc("checksum") }}'
+      - name: materialization
+        description: '{{ doc("materialization") }}'
+      - name: tags
+        description: '{{ doc("tags") }}'
+      - name: meta
+        description: '{{ doc("meta") }}'
+      - name: description
+        description: ''
+        config:
+          meta:
+            label: Description
+      - name: total_rowcount
+        description: 'Total rowcount for the model'

--- a/models/sources/seeds.yml
+++ b/models/sources/seeds.yml
@@ -1,24 +1,23 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: seeds
     description: Dimension model that contains data about seeds.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: database_name
-      description: '{{ doc("database_name") }}'
-    - name: schema_name
-      description: '{{ doc("schema_name") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: package_name
-      description: '{{ doc("package_name") }}'
-    - name: path
-      description: '{{ doc("path") }}'
-    - name: checksum
-      description: '{{ doc("checksum") }}'
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: database_name
+        description: '{{ doc("database_name") }}'
+      - name: schema_name
+        description: '{{ doc("schema_name") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: package_name
+        description: '{{ doc("package_name") }}'
+      - name: path
+        description: '{{ doc("path") }}'
+      - name: checksum
+        description: '{{ doc("checksum") }}'

--- a/models/sources/snapshots.yml
+++ b/models/sources/snapshots.yml
@@ -1,28 +1,27 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: snapshots
     description: Dimension model that contains data about snapshots.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: database_name
-      description: '{{ doc("database_name") }}'
-    - name: schema_name
-      description: '{{ doc("schema_name") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: depends_on_nodes
-      description: '{{ doc("depends_on_nodes") }}'
-    - name: package_name
-      description: '{{ doc("package_name") }}'
-    - name: path
-      description: '{{ doc("path") }}'
-    - name: checksum
-      description: '{{ doc("checksum") }}'
-    - name: strategy
-      description: '{{ doc("strategy") }}'
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: database_name
+        description: '{{ doc("database_name") }}'
+      - name: schema_name
+        description: '{{ doc("schema_name") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: depends_on_nodes
+        description: '{{ doc("depends_on_nodes") }}'
+      - name: package_name
+        description: '{{ doc("package_name") }}'
+      - name: path
+        description: '{{ doc("path") }}'
+      - name: checksum
+        description: '{{ doc("checksum") }}'
+      - name: strategy
+        description: '{{ doc("strategy") }}'

--- a/models/sources/sources.yml
+++ b/models/sources/sources.yml
@@ -1,30 +1,29 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: sources
     description: Dimension model that contains data about sources.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: database_name
-      description: '{{ doc("database_name") }}'
-    - name: schema_name
-      description: '{{ doc("schema_name") }}'
-    - name: source_name
-      description: '{{ doc("source_name") }}'
-    - name: loader
-      description: '{{ doc("loader") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: identifier
-      description: '{{ doc("identifier") }}'
-    - name: loaded_at_field
-      description: '{{ doc("loaded_at_field") }}'
-    - name: freshness
-      description: '{{ doc("freshness") }}'
-    - name: total_rowcount
-      description: '{{ doc("total_rowcount") }}'
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: database_name
+        description: '{{ doc("database_name") }}'
+      - name: schema_name
+        description: '{{ doc("schema_name") }}'
+      - name: source_name
+        description: '{{ doc("source_name") }}'
+      - name: loader
+        description: '{{ doc("loader") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: identifier
+        description: '{{ doc("identifier") }}'
+      - name: loaded_at_field
+        description: '{{ doc("loaded_at_field") }}'
+      - name: freshness
+        description: '{{ doc("freshness") }}'
+      - name: total_rowcount
+        description: '{{ doc("total_rowcount") }}'

--- a/models/sources/tests.yml
+++ b/models/sources/tests.yml
@@ -1,54 +1,53 @@
 version: 2
-dbt_observability:
-  models:
+models:
   - name: tests
     description: Dimension model that contains data about tests.
     columns:
-    - name: command_invocation_id
-      description: '{{ doc("command_invocation_id") }}'
-    - name: node_id
-      description: '{{ doc("node_id") }}'
-    - name: run_started_at
-      description: '{{ doc("run_started_at") }}'
-    - name: name
-      description: '{{ doc("name") }}'
-    - name: description
-      description: '{{ doc("description") }}'
-    - name: depends_on_nodes
-      description: '{{ doc("depends_on_nodes") }}'
-    - name: package_name
-      description: '{{ doc("package_name") }}'
-    - name: test_path
-      description: '{{ doc("test_path") }}'
-    - name: tags
-      description: '{{ doc("tags") }}'
-    - name: test_metadata
-      description: ''
-    - name: column_name
-      description: The column the test is attached to in the schema yml, when the test is defined under a column. Null for model-level and singular tests.
-    - name: attached_node
-      description: The node_id of the model, source, seed, or snapshot the test is attached to. Available on dbt 1.6+; null otherwise.
-    - name: test_package
-      description: Package namespace the generic test comes from (test_metadata.namespace), e.g. dbt_utils. Null for singular tests.
-    - name: test_name
-      description: Generic test type (test_metadata.name), e.g. not_null, unique, relationships. Null for singular tests.
-    - name: test_model
-      description: Raw ref()/source() expression the test is attached to (test_metadata.kwargs.model).
-    - name: test_combination_of_columns
-      description: Comma-separated columns for composite tests, e.g. unique_combination_of_columns (test_metadata.kwargs.combination_of_columns).
-    - name: test_column_value
-      description: Expected value for accepted_values-style tests (test_metadata.kwargs.value).
-    - name: test_column_min_value
-      description: Minimum bound for range tests (test_metadata.kwargs.min_value). Stored as text; cast downstream.
-    - name: test_column_max_value
-      description: Maximum bound for range tests (test_metadata.kwargs.max_value). Stored as text; cast downstream.
-    - name: test_relationship_from_model_condition
-      description: from_condition filter on a relationships test (test_metadata.kwargs.from_condition).
-    - name: test_to_model
-      description: Target model of a relationships test (test_metadata.kwargs.to / compare_model).
-    - name: test_relationship_to_field
-      description: Target field of a relationships test (test_metadata.kwargs.field).
-    - name: test_relationship_to_model_condition
-      description: to_condition filter on a relationships test (test_metadata.kwargs.to_condition).
-    - name: test_column_expression
-      description: Expression for expression-style tests (test_metadata.kwargs.expression).
+      - name: command_invocation_id
+        description: '{{ doc("command_invocation_id") }}'
+      - name: node_id
+        description: '{{ doc("node_id") }}'
+      - name: run_started_at
+        description: '{{ doc("run_started_at") }}'
+      - name: name
+        description: '{{ doc("name") }}'
+      - name: description
+        description: '{{ doc("description") }}'
+      - name: depends_on_nodes
+        description: '{{ doc("depends_on_nodes") }}'
+      - name: package_name
+        description: '{{ doc("package_name") }}'
+      - name: test_path
+        description: '{{ doc("test_path") }}'
+      - name: tags
+        description: '{{ doc("tags") }}'
+      - name: test_metadata
+        description: ''
+      - name: column_name
+        description: The column the test is attached to in the schema yml, when the test is defined under a column. Null for model-level and singular tests.
+      - name: attached_node
+        description: The node_id of the model, source, seed, or snapshot the test is attached to. Available on dbt 1.6+; null otherwise.
+      - name: test_package
+        description: Package namespace the generic test comes from (test_metadata.namespace), e.g. dbt_utils. Null for singular tests.
+      - name: test_name
+        description: Generic test type (test_metadata.name), e.g. not_null, unique, relationships. Null for singular tests.
+      - name: test_model
+        description: Raw ref()/source() expression the test is attached to (test_metadata.kwargs.model).
+      - name: test_combination_of_columns
+        description: Comma-separated columns for composite tests, e.g. unique_combination_of_columns (test_metadata.kwargs.combination_of_columns).
+      - name: test_column_value
+        description: Expected value for accepted_values-style tests (test_metadata.kwargs.value).
+      - name: test_column_min_value
+        description: Minimum bound for range tests (test_metadata.kwargs.min_value). Stored as text; cast downstream.
+      - name: test_column_max_value
+        description: Maximum bound for range tests (test_metadata.kwargs.max_value). Stored as text; cast downstream.
+      - name: test_relationship_from_model_condition
+        description: from_condition filter on a relationships test (test_metadata.kwargs.from_condition).
+      - name: test_to_model
+        description: Target model of a relationships test (test_metadata.kwargs.to / compare_model).
+      - name: test_relationship_to_field
+        description: Target field of a relationships test (test_metadata.kwargs.field).
+      - name: test_relationship_to_model_condition
+        description: to_condition filter on a relationships test (test_metadata.kwargs.to_condition).
+      - name: test_column_expression
+        description: Expression for expression-style tests (test_metadata.kwargs.expression).


### PR DESCRIPTION
Fix deprecation warnings. See [dbt docs](https://docs.getdbt.com/reference/deprecations?version=1.11&name=Core) on deprecations.

Live `.yml` updated.  Only YAML updates so testing was done via:
```bash
dbt parse  --show-all-deprecations --no-partial-parse
```

Incorrect indentation has also been corrected.

Proposed as a minor upgrade from 3.4.2 to 3.5.0